### PR TITLE
Normalize line endings (.gitattributes) + previously staged fixes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This PR adds .gitattributes to normalize line endings across Windows/Linux environments (Render uses LF):

- .gitattributes: `* text=auto`

This prevents CRLF/LF warnings and ensures Render reads files correctly.

Notes:
- The functional fixes discussed (reports print URLs, user Active via AppKV, robust customer/supplier delete fallback, purchases form context) are already present on the current codebase in this repository. If any of them are not yet on main in your remote deployment, let me know and I will open a separate PR or push the missing commits.

Target branch: main.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author