### PR TITLE
POS: Qty controls (+/-), supervisor password on minus; checkout model fix; settings save fix; currency image in receipts

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask, render_template, request, redirect, url_for
 from flask_login import LoginManager, UserMixin, login_user, login_required, logout_user, current_user
 

--- a/templates/invoice_print.html
+++ b/templates/invoice_print.html
@@ -281,8 +281,8 @@
                 <tbody>
                     {% for item in items %}
                     <tr>
-                        <td>{{ "%.2f"|format(item.total_price or (item.quantity * (item.unit_price or item.price_before_tax))) }} {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% endif %}</td>
-                        <td>{{ "%.2f"|format(item.unit_price or item.price_before_tax) }} {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% endif %}</td>
+                        <td>{{ "%.2f"|format(item.total_price or (item.quantity * (item.unit_price or item.price_before_tax))) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td>
+                        <td>{{ "%.2f"|format(item.unit_price or item.price_before_tax) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td>
                         <td>{{ item.quantity }}</td>
                         <td>{{ item.product_name }}</td>
                         <td>{{ loop.index }}</td>
@@ -300,21 +300,21 @@
             <table class="totals-table">
                 <tr>
                     <td class="total-label">Subtotal:</td>
-                    <td class="total-amount">{{ "%.2f"|format(invoice.total_before_tax or invoice.subtotal or 0) }} {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% endif %}</td>
+                    <td class="total-amount">{{ "%.2f"|format(invoice.total_before_tax or invoice.subtotal or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td>
                 </tr>
                 {% if invoice.discount_amount and invoice.discount_amount > 0 %}
                 <tr>
                     <td class="total-label">Discount:</td>
-                    <td class="total-amount">- {{ "%.2f"|format(invoice.discount_amount) }} {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% endif %}</td>
+                    <td class="total-amount">- {{ "%.2f"|format(invoice.discount_amount) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td>
                 </tr>
                 {% endif %}
                 <tr>
                     <td class="total-label">Tax (15%):</td>
-                    <td class="total-amount">{{ "%.2f"|format(invoice.tax_amount or 0) }} {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% endif %}</td>
+                    <td class="total-amount">{{ "%.2f"|format(invoice.tax_amount or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td>
                 </tr>
                 <tr class="grand-total">
                     <td class="total-label">Grand Total:</td>
-                    <td class="total-amount">{{ "%.2f"|format(invoice.total_after_tax_discount or invoice.total_amount or 0) }} {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% endif %}</td>
+                    <td class="total-amount">{{ "%.2f"|format(invoice.total_after_tax_discount or invoice.total_amount or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td>
                 </tr>
             </table>
         </div>

--- a/templates/print/receipt.html
+++ b/templates/print/receipt.html
@@ -80,24 +80,24 @@
         <tr>
           <td>{{ it.product_name }}</td>
           <td class="center">{{ '%.2f'|format(it.quantity or 0) }}</td>
-          <td class="center">{{ '%.2f'|format(((it.total_price or 0) / (it.quantity or 1))) }} {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif settings and settings.currency %} {{ settings.currency }}{% endif %}</td>
-          <td class="right">{{ '%.2f'|format(it.total_price or 0) }} {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif settings and settings.currency %} {{ settings.currency }}{% endif %}</td>
+          <td class="center">{{ '%.2f'|format(((it.total_price or 0) / (it.quantity or 1))) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td>
+          <td class="right">{{ '%.2f'|format(it.total_price or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td>
         </tr>
         {% endfor %}
       </tbody>
       <tfoot>
-        <tr class="total-row"><td colspan="3">{{ _('Subtotal') }}</td><td class="right">{{ '%.2f'|format(inv.total_before_tax or 0) }} {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif settings and settings.currency %} {{ settings.currency }}{% endif %}</td></tr>
-        <tr class="total-row"><td colspan="3">{{ _('VAT 15%%') }}</td><td class="right">{{ '%.2f'|format(inv.tax_amount or 0) }} {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif settings and settings.currency %} {{ settings.currency }}{% endif %}</td></tr>
+        <tr class="total-row"><td colspan="3">{{ _('Subtotal') }}</td><td class="right">{{ '%.2f'|format(inv.total_before_tax or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td></tr>
+        <tr class="total-row"><td colspan="3">{{ _('VAT 15%%') }}</td><td class="right">{{ '%.2f'|format(inv.tax_amount or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td></tr>
         {% if inv.discount_amount and inv.discount_amount > 0 %}
         {% set base_total = (inv.total_before_tax or 0) %}
         {% set rate = (inv.discount_amount / base_total * 100) if base_total > 0 else 0 %}
         {% set cust = (inv.customer_name or '')|upper %}
         <tr class="total-row" style="color: #d63384;">
           <td colspan="3">{{ _('Discount') }}{% if cust in ['KEETA','HUNGER'] %} ({{ '%.2f'|format(rate or 0) }}%){% endif %}</td>
-          <td class="right">-{{ '%.2f'|format(inv.discount_amount or 0) }} {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif settings and settings.currency %} {{ settings.currency }}{% endif %}</td>
+          <td class="right">-{{ '%.2f'|format(inv.discount_amount or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td>
         </tr>
         {% endif %}
-        <tr class="total-row" style="font-weight: bold; border-top: 2px solid #000;"><td colspan="3">{{ _('Grand Total') }}</td><td class="right">{{ '%.2f'|format(inv.total_after_tax_discount or 0) }} {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif settings and settings.currency %} {{ settings.currency }}{% endif %}</td></tr>
+        <tr class="total-row" style="font-weight: bold; border-top: 2px solid #000;"><td colspan="3">{{ _('Grand Total') }}</td><td class="right">{{ '%.2f'|format(inv.total_after_tax_discount or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td></tr>
       </tfoot>
     </table>
 

--- a/templates/receipt.html
+++ b/templates/receipt.html
@@ -175,24 +175,10 @@
                     <td>{{ item.product_name }}</td>
                     <td class="qty">{{ item.quantity }}</td>
                     <td class="unit">
-                        {% if currency_data_url %}
-                        <span class="currency-amount">
-                            <img src="{{ currency_data_url }}" class="currency-img" alt="SAR">
-                            {{ '%.2f'|format(item.price_before_tax or 0) }}
-                        </span>
-                        {% else %}
-                        {{ '%.2f'|format(item.price_before_tax or 0) }} SAR
-                        {% endif %}
+                        <span class="currency-amount">{{ '%.2f'|format(item.price_before_tax or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" class="currency-img" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" class="currency-img" alt="currency">{% endif %}</span>
                     </td>
                     <td class="total">
-                        {% if currency_data_url %}
-                        <span class="currency-amount">
-                            <img src="{{ currency_data_url }}" class="currency-img" alt="SAR">
-                            {{ '%.2f'|format(item.total_price or ((item.quantity or 0) * (item.price_before_tax or 0))) }}
-                        </span>
-                        {% else %}
-                        {{ '%.2f'|format(item.total_price or ((item.quantity or 0) * (item.price_before_tax or 0))) }} SAR
-                        {% endif %}
+                        <span class="currency-amount">{{ '%.2f'|format(item.total_price or ((item.quantity or 0) * (item.price_before_tax or 0))) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" class="currency-img" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" class="currency-img" alt="currency">{% endif %}</span>
                     </td>
                 </tr>
                 {% endfor %}
@@ -204,14 +190,7 @@
             <div class="total-row">
                 <span>Subtotal:</span>
                 <span>
-                    {% if currency_data_url %}
-                    <span class="currency-amount">
-                        <img src="{{ currency_data_url }}" class="currency-img" alt="SAR">
-                        {{ '%.2f'|format(invoice.total_before_tax or 0) }}
-                    </span>
-                    {% else %}
-                    {{ '%.2f'|format(invoice.total_before_tax or 0) }} SAR
-                    {% endif %}
+                    <span class="currency-amount">{{ '%.2f'|format(invoice.total_before_tax or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" class="currency-img" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" class="currency-img" alt="currency">{% endif %}</span>
                 </span>
             </div>
             
@@ -222,14 +201,7 @@
             <div class="total-row">
                 <span>Discount{% if cust in ['KEETA','HUNGER'] %} ({{ '%.2f'|format(rate or 0) }}%){% endif %}:</span>
                 <span>
-                    {% if currency_data_url %}
-                    <span class="currency-amount">
-                        <img src="{{ currency_data_url }}" class="currency-img" alt="SAR">
-                        -{{ '%.2f'|format(invoice.discount_amount or 0) }}
-                    </span>
-                    {% else %}
-                    -{{ '%.2f'|format(invoice.discount_amount or 0) }} SAR
-                    {% endif %}
+                    <span class="currency-amount">-{{ '%.2f'|format(invoice.discount_amount or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" class="currency-img" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" class="currency-img" alt="currency">{% endif %}</span>
                 </span>
             </div>
             {% endif %}
@@ -237,28 +209,14 @@
             <div class="total-row">
                 <span>VAT (15%):</span>
                 <span>
-                    {% if currency_data_url %}
-                    <span class="currency-amount">
-                        <img src="{{ currency_data_url }}" class="currency-img" alt="SAR">
-                        {{ '%.2f'|format(invoice.tax_amount or 0) }}
-                    </span>
-                    {% else %}
-                    {{ '%.2f'|format(invoice.tax_amount or 0) }} SAR
-                    {% endif %}
+                    <span class="currency-amount">{{ '%.2f'|format(invoice.tax_amount or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" class="currency-img" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" class="currency-img" alt="currency">{% endif %}</span>
                 </span>
             </div>
             
             <div class="total-row grand-total">
                 <span>Total:</span>
                 <span>
-                    {% if currency_data_url %}
-                    <span class="currency-amount">
-                        <img src="{{ currency_data_url }}" class="currency-img" alt="SAR">
-                        {{ '%.2f'|format(invoice.total_after_tax_discount or 0) }}
-                    </span>
-                    {% else %}
-                    {{ '%.2f'|format(invoice.total_after_tax_discount or 0) }} SAR
-                    {% endif %}
+                    <span class="currency-amount">{{ '%.2f'|format(invoice.total_after_tax_discount or 0) }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" class="currency-img" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" class="currency-img" alt="currency">{% endif %}</span>
                 </span>
             </div>
         </div>

--- a/templates/receipt_print.html
+++ b/templates/receipt_print.html
@@ -121,21 +121,21 @@
         <table class="totals">
             <tr>
                 <td>Subtotal</td>
-                <td style="text-align:right">{{ '%.2f' % subtotal }} SAR</td>
+                <td style="text-align:right">{{ '%.2f' % subtotal }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td>
             </tr>
             {% if invoice.discount_amount and invoice.discount_amount > 0 %}
             <tr>
                 <td>Discount</td>
-                <td style="text-align:right">-{{ '%.2f' % invoice.discount_amount }} SAR</td>
+                <td style="text-align:right">-{{ '%.2f' % invoice.discount_amount }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td>
             </tr>
             {% endif %}
             <tr>
                 <td>VAT ({{ (settings.vat_rate if settings else 15)|int }}%)</td>
-                <td style="text-align:right">{{ '%.2f' % vat_amount }} SAR</td>
+                <td style="text-align:right">{{ '%.2f' % vat_amount }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</td>
             </tr>
             <tr style="border-top: 2px solid #333;">
                 <td><strong>Total</strong></td>
-                <td style="text-align:right"><strong>{{ '%.2f' % total }} SAR</strong></td>
+                <td style="text-align:right"><strong>{{ '%.2f' % total }}{% if settings and settings.currency_image %} <img src="{{ settings.currency_image }}" width="12" height="12" alt="currency">{% elif currency_data_url %} <img src="{{ currency_data_url }}" width="12" height="12" alt="currency">{% endif %}</strong></td>
             </tr>
         </table>
 

--- a/templates/sales_table_invoice.html
+++ b/templates/sales_table_invoice.html
@@ -117,9 +117,9 @@
 
             <div class="d-flex justify-content-end gap-3">
               <div><strong>Subtotal</strong>: <span id="subtotal">0.00</span> {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="14" height="14" alt="currency">{% elif settings and settings.currency %} {{ settings.currency }}{% endif %}</div>
-              <div><strong>Tax</strong>: <span id="tax">0.00</span> {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="14" height="14" alt="currency">{% elif settings and settings.currency %} {{ settings.currency }}{% endif %}</div>
-              <div><strong>Discount</strong>: <span id="discount">0.00</span> {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="14" height="14" alt="currency">{% elif settings and settings.currency %} {{ settings.currency }}{% endif %}</div>
-              <div><strong>Grand Total</strong>: <span id="grand">0.00</span> {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="14" height="14" alt="currency">{% elif settings and settings.currency %} {{ settings.currency }}{% endif %}</div>
+              <div><strong>Tax</strong>: <span id="tax">0.00</span> {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="14" height="14" alt="currency">{% endif %}</div>
+              <div><strong>Discount</strong>: <span id="discount">0.00</span> {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="14" height="14" alt="currency">{% endif %}</div>
+              <div><strong>Grand Total</strong>: <span id="grand">0.00</span> {% if settings and settings.currency_image %}<img src="{{ settings.currency_image }}" width="14" height="14" alt="currency">{% endif %}</div>
             </div>
           </div>
 

--- a/tests/local_pay_print_test.py
+++ b/tests/local_pay_print_test.py
@@ -1,0 +1,106 @@
+import json
+import pathlib
+import importlib.util
+
+# Load packaged app from app/__init__.py explicitly to avoid name clash with app.py
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+import sys
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+spec = importlib.util.spec_from_file_location("pkg_app", str(ROOT / "app" / "__init__.py"))
+app_mod = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(app_mod)
+
+create_app = getattr(app_mod, 'create_app')
+db = getattr(app_mod, 'db')
+
+# Build app
+app = create_app()
+app.config['TESTING'] = True
+app.config['WTF_CSRF_ENABLED'] = False
+
+from app.models import User  # type: ignore
+
+
+def ensure_admin():
+    with app.app_context():
+        try:
+            db.create_all()
+        except Exception:
+            pass
+        u = User.query.filter_by(username='admin').first()
+        if not u:
+            u = User(username='admin')
+            u.set_password('admin123')
+            db.session.add(u)
+            db.session.commit()
+
+
+def run():
+    ensure_admin()
+    results = []
+    errors = []
+    with app.app_context():
+        with app.test_client() as c:
+            # Login (creates default admin if not exists)
+            r = c.post('/login', data={'username': 'admin', 'password': 'admin123'}, follow_redirects=True)
+            if r.status_code != 200:
+                errors.append(f'Login failed HTTP {r.status_code}')
+            else:
+                results.append('Login OK')
+
+            # Open POS page (China Town table 1)
+            r = c.get('/pos/china_town/table/1', follow_redirects=True)
+            if r.status_code != 200:
+                errors.append(f'Open POS failed HTTP {r.status_code}')
+            else:
+                results.append('POS open OK')
+
+            # Checkout directly via sales API (no draft)
+            payload = {
+                'branch_code': 'china_town',
+                'table_number': 1,
+                'items': [
+                    {'name': 'Test Item', 'price': 10.0, 'qty': 2}
+                ],
+                'discount_pct': 0,
+                'tax_pct': 15,
+                'payment_method': 'CASH',
+            }
+            r = c.post('/api/sales/checkout', data=json.dumps(payload), content_type='application/json')
+            if r.status_code != 200:
+                errors.append(f'Checkout failed HTTP {r.status_code}: {r.data.decode("utf-8", "ignore")[:200]}')
+            else:
+                j = r.get_json(silent=True) or {}
+                invoice_id = j.get('invoice_id')
+                if not invoice_id:
+                    errors.append('Checkout response missing invoice_id')
+                else:
+                    results.append(f'Checkout OK invoice={invoice_id}')
+                    # Call confirm-print to finalize/post
+                    r2 = c.post('/api/invoice/confirm-print', data=json.dumps({
+                        'invoice_id': invoice_id,
+                        'payment_method': j.get('payment_method'),
+                        'total_amount': j.get('total_amount'),
+                        'branch_code': j.get('branch_code'),
+                        'table_number': j.get('table_number'),
+                    }), content_type='application/json')
+                    if r2.status_code != 200:
+                        errors.append(f'Confirm-print failed HTTP {r2.status_code}: {r2.data.decode("utf-8", "ignore")[:200]}')
+                    else:
+                        results.append('Confirm-print OK (invoice posted)')
+
+    for line in results:
+        print(line)
+    if errors:
+        print('ERRORS:')
+        for e in errors:
+            print(' -', e)
+        raise SystemExit(1)
+    raise SystemExit(0)
+
+
+if __name__ == '__main__':
+    run()
+


### PR DESCRIPTION
Summary of changes:

- POS sales table UI: replaced native number input spinners with external + and − buttons; minus requires supervisor password `1991`. Quantity field is read-only display now.
- Checkout APIs: align fields with actual SalesInvoice/SalesInvoiceItem models:
  - Compute and store total_before_tax, tax_amount, discount_amount, total_after_tax_discount
  - Use product_name, quantity, price_before_tax for items
  - Store user_id for audit
- Settings save: prevent clearing existing values when posting empty strings; only update when a non-empty value is provided.
- Receipts/prints: use currency image from settings (PNG) consistently.
- Added local smoke test scaffold.

Please review and merge into main. Target branch: main (per project convention).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author