### PR TITLE
fix(purchases): populate supplier fields on selection

### DIFF
--- a/templates/purchases.html
+++ b/templates/purchases.html
@@ -345,7 +345,7 @@ body {
 
 <script>
 (function(){
-  const SUPPLIERS = JSON.parse({{ (suppliers_json or '[]') | tojson | safe }});
+  const SUPPLIERS = {{ (suppliers_json or '[]') | tojson | safe }};
   const input = document.getElementById('supplier_select');
   const hiddenId = document.getElementById('supplier_id');
   const phone = document.getElementById('s_phone');


### PR DESCRIPTION
- Remove erroneous JSON.parse around tojson output for SUPPLIERS list, which caused runtime error and prevented filling phone/tax/address fields on change.
- Now supplier details are correctly filled when selecting a supplier.